### PR TITLE
fix(gh): セマンティックバージョニングに適合した形でバージョンを振るように

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         git fetch origin $head
         git checkout FETCH_HEAD
         brew install jaq
-        jaq --in-place ".version |= (. + \"-hanami.$(git rev-parse --short HEAD)\")" package.json
+        jaq --in-place ".version |= sub(\"^(?<a>\\\\d+\\\\.\\\\d+\\\\.\\\\d+)(-.*)?$\"; \"\(.a)-hanami.$(git log --oneline | wc -l)+$(git rev-parse --short HEAD)\")" package.json
         docker build -t "${{ secrets.DOCKERHUB_USERNAME }}/deployment-manager:$GITHUB_REF_NAME-misskey" .
         docker push "${{ secrets.DOCKERHUB_USERNAME }}/deployment-manager:$GITHUB_REF_NAME-misskey"
         echo "digest=$(docker image ls --format '{{.Digest}}' | head -n1)" > $GITHUB_OUTPUT


### PR DESCRIPTION
## What
- `2025.1.0-beta.0` → `2025.1.0-hanami.<commit qty>+<commit hash>`
- `2025.1.0` → `2025.1.0-hanami.<commit qty>+<commit hash>`

に書き換わるように

## Why
Misskeyの更新ダイアログが毎回開くようになる